### PR TITLE
Support CUDA/C++/PTX output from Slang

### DIFF
--- a/src/ShaderPlayground.Core/Compilers/Slang/SlangCompiler.cs
+++ b/src/ShaderPlayground.Core/Compilers/Slang/SlangCompiler.cs
@@ -9,14 +9,14 @@ namespace ShaderPlayground.Core.Compilers.Slang
         public string Url { get; } = "https://github.com/shader-slang/slang";
         public string Description { get; } = "Slang is a shading language that extends HLSL with new capabilities for building modular, extensible, and high-performance real-time shading systems";
 
-        public string[] InputLanguages { get; } = { LanguageNames.Slang, LanguageNames.Hlsl, LanguageNames.Cpp, LanguageNames.Cuda };
+        public string[] InputLanguages { get; } = { LanguageNames.Slang, LanguageNames.Hlsl };
 
         public ShaderCompilerParameter[] Parameters { get; } =
         {
             CommonParameters.CreateVersionParameter("slang"),
             CommonParameters.HlslEntryPoint,
             new ShaderCompilerParameter("Profile", "Profile", ShaderCompilerParameterType.ComboBox, ProfileOptions, "cs_5_0"),
-            CommonParameters.CreateOutputParameter(new[] { LanguageNames.Hlsl, LanguageNames.Glsl })
+            CommonParameters.CreateOutputParameter(new[] { LanguageNames.Hlsl, LanguageNames.Glsl, LanguageNames.Cpp, LanguageNames.Cuda, LanguageNames.Ptx })
         };
 
         private static readonly string[] ProfileOptions =
@@ -65,6 +65,10 @@ namespace ShaderPlayground.Core.Compilers.Slang
                     
                 case LanguageNames.Cpp:
                     args += " -target cpp";
+                    break;
+                
+                case LanguageNames.Ptx:
+                    args += " -target ptx";
                     break;
             }
 

--- a/src/ShaderPlayground.Core/Compilers/Slang/SlangCompiler.cs
+++ b/src/ShaderPlayground.Core/Compilers/Slang/SlangCompiler.cs
@@ -9,7 +9,7 @@ namespace ShaderPlayground.Core.Compilers.Slang
         public string Url { get; } = "https://github.com/shader-slang/slang";
         public string Description { get; } = "Slang is a shading language that extends HLSL with new capabilities for building modular, extensible, and high-performance real-time shading systems";
 
-        public string[] InputLanguages { get; } = { LanguageNames.Slang, LanguageNames.Hlsl };
+        public string[] InputLanguages { get; } = { LanguageNames.Slang, LanguageNames.Hlsl, LanguageNames.Cpp, LanguageNames.Cuda };
 
         public ShaderCompilerParameter[] Parameters { get; } =
         {
@@ -57,6 +57,14 @@ namespace ShaderPlayground.Core.Compilers.Slang
 
                 case LanguageNames.Hlsl:
                     args += " -target hlsl";
+                    break;
+                    
+                case LanguageNames.Cuda:
+                    args += " -target cuda";
+                    break;
+                    
+                case LanguageNames.Cpp:
+                    args += " -target cpp";
                     break;
             }
 

--- a/src/ShaderPlayground.Core/LanguageNames.cs
+++ b/src/ShaderPlayground.Core/LanguageNames.cs
@@ -20,5 +20,6 @@
         public const string Zlib = "zlib";
         public const string Zstd = "zst";
         public const string Cuda = "CUDA";
+        public const string Ptx = "PTX";
     }
 }

--- a/src/ShaderPlayground.Core/LanguageNames.cs
+++ b/src/ShaderPlayground.Core/LanguageNames.cs
@@ -19,5 +19,6 @@
         public const string Yariv = "YARI-V";
         public const string Zlib = "zlib";
         public const string Zstd = "zst";
+        public const string Cuda = "CUDA";
     }
 }


### PR DESCRIPTION
Slang has added support for CUDA and C++ targets. 

It also supports PTX, but requires Slang to have nvrtc compiler available to Slang (say in same directory as slang binary). A little more about this is in [Slang CUDA docs](https://github.com/shader-slang/slang/blob/master/docs/cuda-target.md)

Note - I didn't get to compile/test, because doing so required Visual Studio installing GBs of stuff. 