### PR TITLE
Change default GLSL to version 460

### DIFF
--- a/src/ShaderPlayground.Core/Languages/GlslLanguage.cs
+++ b/src/ShaderPlayground.Core/Languages/GlslLanguage.cs
@@ -8,11 +8,13 @@
 
         public string FileExtension { get; } = "glsl";
 
-        private static readonly string DefaultGlslCode = @"#version 330
+        private static readonly string DefaultGlslCode = @"#version 460
+
+layout (location = 0) out vec4 fragColor;
 
 void main()
 {
-	gl_FragColor = vec4(0.4, 0.4, 0.8, 1.0);
+	fragColor = vec4(0.4, 0.4, 0.8, 1.0);
 }";
     }
 }


### PR DESCRIPTION
Version 330 is extremely outdated, and trying to test out new things usually means manually making the above change every time I interact with the playground. I imagine most of the traffic is from HLSL users, but this change would save me (and hopefully others) making this same change every time. I would be surprised if anyone was actively still choosing to use version 330, but would be happy to drop this if it turns out to be the case.