### PR TITLE
Properly fix ANGLE build

### DIFF
--- a/external/angle/build.bat
+++ b/external/angle/build.bat
@@ -10,7 +10,7 @@ if EXIST "%PYTHON2%" (
     call python scripts/bootstrap.py
 )
 
-call gclient sync
+call gclient sync --no-history
 call git checkout master
 
 call gn gen out/Release

--- a/external/angle/build.bat
+++ b/external/angle/build.bat
@@ -11,8 +11,5 @@ if EXIST "%PYTHON2%" (
 )
 
 call gclient sync --no-history
-call git checkout master
-
 call gn gen out/Release
-
 call ninja -C out/Release angle_shader_translator

--- a/external/tint/build.bat
+++ b/external/tint/build.bat
@@ -6,7 +6,7 @@ if NOT EXIST "./scripts/bootstrap.py" (
 
 if NOT EXIST ".gclient" (
     copy standalone.gclient .gclient
-    call gclient sync
+    call gclient sync --no-history
 )
 
 mkdir build


### PR DESCRIPTION
The `git checkout master` line pulls the ANGLE project forward from the submodule snapshot revision.
This leads to hilarity when its dependencies are no longer compatible.

Also pass `--no-history` for a happier download experience.

Issue: #73 