### PR TITLE
Add DXIL, SPIR-V & DXBC targets for Slang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2021-06-22
+
+* Added DXIL, SPIR-V & DXBC targets for Slang (#96)
+
 ## 2021-04-15
 
 * Added Mali offline compiler 7.3.0

--- a/build.cake
+++ b/build.cake
@@ -364,6 +364,8 @@ Task("Download-Slang")
         "bin/windows-x64/release/*.*");
 
       CopyFiles(nvrtcPaths, binariesFolder);
+
+      CopyFiles($"./src/ShaderPlayground.Core/Binaries/dxc/trunk/dxcompiler.dll", binariesFolder);
     }
 
     DownloadSlang("0.10.24");
@@ -371,6 +373,8 @@ Task("Download-Slang")
     DownloadSlang("0.10.26");
     DownloadSlang("0.11.18");
     DownloadSlang("0.13.10");
+    DownloadSlang("0.18.0");
+    DownloadSlang("0.18.25");
   });
 
 Task("Download-HLSLParser")

--- a/src/ShaderPlayground.Core/Compilers/Slang/SlangCompiler.cs
+++ b/src/ShaderPlayground.Core/Compilers/Slang/SlangCompiler.cs
@@ -14,9 +14,19 @@ namespace ShaderPlayground.Core.Compilers.Slang
         public ShaderCompilerParameter[] Parameters { get; } =
         {
             CommonParameters.CreateVersionParameter("slang"),
-            CommonParameters.HlslEntryPoint,
+            // The default HLSL entry point (CommonParameters.HlslEntryPoint) uses PSMain, but the Slang sample is a compute shader with "computeMain"
+            new ShaderCompilerParameter("EntryPoint", "Entry point", ShaderCompilerParameterType.TextBox, defaultValue: "computeMain"),
             new ShaderCompilerParameter("Profile", "Profile", ShaderCompilerParameterType.ComboBox, ProfileOptions, "cs_5_0"),
-            CommonParameters.CreateOutputParameter(new[] { LanguageNames.Hlsl, LanguageNames.Glsl, LanguageNames.Cpp, LanguageNames.Cuda, LanguageNames.Ptx })
+            new ShaderCompilerParameter("OptimizationLevel", "Optimization level", ShaderCompilerParameterType.ComboBox, OptimizationLevelOptions, "Default"),
+            CommonParameters.CreateOutputParameter(new[] { LanguageNames.Dxil, LanguageNames.SpirV, LanguageNames.Dxbc, LanguageNames.Hlsl, LanguageNames.Glsl, LanguageNames.Cpp, LanguageNames.Cuda, LanguageNames.Ptx })
+        };
+
+        private static readonly string[] OptimizationLevelOptions =
+        {
+            "None",
+            "Default",
+            "High",
+            "Maximal",
         };
 
         private static readonly string[] ProfileOptions =
@@ -66,9 +76,40 @@ namespace ShaderPlayground.Core.Compilers.Slang
                 case LanguageNames.Cpp:
                     args += " -target cpp";
                     break;
-                
+
                 case LanguageNames.Ptx:
                     args += " -target ptx";
+                    break;
+
+                case LanguageNames.Dxil:
+                    args += " -target dxil-assembly";
+                    break;
+
+                case LanguageNames.SpirV:
+                    args += " -target spirv-assembly";
+                    break;
+
+                case LanguageNames.Dxbc:
+                    args += " -target dxbc-assembly";
+                    break;
+            }
+
+            var optimizationLevel = arguments.GetString("OptimizationLevel");
+            switch (optimizationLevel)
+            {
+                case "None":
+                    args += " -O0";
+                    break;
+                case "High":
+                    args += " -O2";
+                    break;
+                case "Maximal":
+                    args += " -O3";
+                    break;
+                case "Default":
+                    args += " -O";
+                    break;
+                default:
                     break;
             }
 

--- a/src/ShaderPlayground.Core/Compilers/Slang/SlangCompiler.cs
+++ b/src/ShaderPlayground.Core/Compilers/Slang/SlangCompiler.cs
@@ -16,7 +16,8 @@ namespace ShaderPlayground.Core.Compilers.Slang
             CommonParameters.CreateVersionParameter("slang"),
             // The default HLSL entry point (CommonParameters.HlslEntryPoint) uses PSMain, but the Slang sample is a compute shader with "computeMain"
             new ShaderCompilerParameter("EntryPoint", "Entry point", ShaderCompilerParameterType.TextBox, defaultValue: "computeMain"),
-            new ShaderCompilerParameter("Profile", "Profile", ShaderCompilerParameterType.ComboBox, ProfileOptions, "cs_5_0"),
+            // Default to cs_6_0 as assuming DXIL will be the default target 
+            new ShaderCompilerParameter("Profile", "Profile", ShaderCompilerParameterType.ComboBox, ProfileOptions, "cs_6_0"),
             new ShaderCompilerParameter("OptimizationLevel", "Optimization level", ShaderCompilerParameterType.ComboBox, OptimizationLevelOptions, "Default"),
             CommonParameters.CreateOutputParameter(new[] { LanguageNames.Dxil, LanguageNames.SpirV, LanguageNames.Dxbc, LanguageNames.Hlsl, LanguageNames.Glsl, LanguageNames.Cpp, LanguageNames.Cuda, LanguageNames.Ptx })
         };
@@ -31,20 +32,86 @@ namespace ShaderPlayground.Core.Compilers.Slang
 
         private static readonly string[] ProfileOptions =
         {
+            // DXBC
             "cs_4_0",
             "cs_4_1",
             "cs_5_0",
+            "cs_5_1",
+            // DXIL
+            "cs_6_0",
+            "cs_6_1",
+            "cs_6_2",
+            "cs_6_3",
+            "cs_6_4",
+            "cs_6_5",
+            "cs_6_6",
+
+            // DXBC
             "ds_5_0",
+            "ds_5_1",
+            // DXIL
+            "ds_6_0",
+            "ds_6_1",
+            "ds_6_2",
+            "ds_6_3",
+            "ds_6_4",
+            "ds_6_5",
+            "ds_6_6",
+
+            // DXBC
             "gs_4_0",
             "gs_4_1",
             "gs_5_0",
+            "gs_5_1",
+            // DXIL
+            "gs_6_0",
+            "gs_6_1",
+            "gs_6_2",
+            "gs_6_3",
+            "gs_6_4",
+            "gs_6_5",
+            "gs_6_6",
+
+            // DXBC
             "hs_5_0",
+            "hs_5_1",
+            // DXIL
+            "hs_6_0",
+            "hs_6_1",
+            "hs_6_2",
+            "hs_6_3",
+            "hs_6_4",
+            "hs_6_5",
+            "hs_6_6",
+
+            // DXBC
             "ps_4_0",
             "ps_4_1",
             "ps_5_0",
+            "ps_5_1",
+            // DXIL
+            "ps_6_0",
+            "ps_6_1",
+            "ps_6_2",
+            "ps_6_3",
+            "ps_6_4",
+            "ps_6_5",
+            "ps_6_6",
+
+            // DXBC
             "vs_4_0",
             "vs_4_1",
             "vs_5_0",
+            "vs_5_1",
+            // DXIL
+            "vs_6_0",
+            "vs_6_1",
+            "vs_6_2",
+            "vs_6_3",
+            "vs_6_4",
+            "vs_6_5",
+            "vs_6_6",
+
             "glsl_vertex",
             "glsl_tess_control",
             "glsl_tess_eval",

--- a/src/ShaderPlayground.Core/ShaderPlayground.Core.csproj
+++ b/src/ShaderPlayground.Core/ShaderPlayground.Core.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ShaderPlayground.Web/wwwroot/js/codemirror-mode-spirv.js
+++ b/src/ShaderPlayground.Web/wwwroot/js/codemirror-mode-spirv.js
@@ -458,6 +458,10 @@
                     stream.skipToEnd();
                     return "comment";
                 }
+                if (ch == '/' && stream.peek() == '/') {
+                    stream.skipToEnd();
+                    return "comment";
+                }
                 if (ch == '"' || ch == "'") {
                     return tokenString(ch)(stream);
                 }


### PR DESCRIPTION
This is an attempt at addressing issue #93

* Add support for dxil, dxbc and SPIR-V assembly output
* Added support for selecting optimization level
* Fix problem with Slang sample entry point is 'computeMain'. Made CS 6.0 default profile, assuming DXIL is default target.
* Added DXIL 6.0+ profiles, and 5.1 for DXBC

Slang is bundled with it's own version of glslang to allow SPIR-V output so should work 'out of the box'. For DXBC output Slang uses the d3d compiler dll. A version of this is typically available on most systems, so this will probably work directly.

For DXIL output Slang uses DXC and for this to work a version of DXC dll must be available to Slang - typically through the PATH. Alternately it can be placed in the same directory as the Slang dll & binaries. 

On looking at 'build.cake' - it's not 100% clear if something should be added here to copy a version of dxc for Slang to use or assume that dxc is available to Slang through PATH.

Note that although I tested that this compiled and seems reasonable - I did not as yet test within web framework.