### PR TITLE
dxc: Add all SPIR-V target versions

### DIFF
--- a/src/ShaderPlayground.Core/Compilers/Dxc/DxcCompiler.cs
+++ b/src/ShaderPlayground.Core/Compilers/Dxc/DxcCompiler.cs
@@ -97,7 +97,11 @@ namespace ShaderPlayground.Core.Compilers.Dxc
         private static readonly string[] SpirvTargetOptions =
         {
             "vulkan1.0",
-            "vulkan1.1"
+            "vulkan1.1",
+            "vulkan1.1spirv1.4",
+            "vulkan1.2",
+            "vulkan1.3",
+            "universal1.5",
         };
 
         private static readonly string[] Enable16BitTypesFilters =


### PR DESCRIPTION
All supported SPIR-V target versions as of https://github.com/microsoft/DirectXShaderCompiler/blob/76fed39c368cf65167e6db00738b212dac024b49/tools/clang/lib/SPIRV/FeatureManager.cpp#L49-L61.

It is currently impossible to pass these as `-fspv-target-env=vulkan1.2` (for example) since [the regex] for extra arguments doesn't seem to allow a literal period (`.`):
```
System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'Invalid value for ExtraOptions: '-fspv-target-env vulkan1.2'')
   at ShaderPlayground.Core.ShaderCompilerArguments.GetString(String name) in C:\Code\shader-playground\src\ShaderPlayground.Core\ShaderCompilerArguments.cs:line 67
   at ShaderPlayground.Core.Compilers.Dxc.DxcCompiler.Compile(ShaderCode shaderCode, ShaderCompilerArguments arguments, List`1 previousCompilerArguments) in C:\Code\shader-playground\src\ShaderPlayground.Core\Compilers\Dxc\DxcCompiler.cs:line 132
   at ShaderPlayground.Core.Compiler.Compile(ShaderCode shaderCode, CompilationStep[] compilationSteps) in C:\Code\shader-playground\src\ShaderPlayground.Core\Compiler.cs:line 128
   at ShaderPlayground.Web.Controllers.ApiController.Compile(ShaderCompilationRequestViewModel model) in C:\Code\shader-playground\src\ShaderPlayground.Web\Controllers\ApiController.cs:line 67
```

[the regex]: https://github.com/tgjones/shader-playground/blob/3e11f35ce0a61d2dab67a1299363b11d5f1d752f/src/ShaderPlayground.Core/ShaderCompilerArguments.cs#L10