### PR TITLE
update slang to v2024.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2024-02-13
+
+Updated Slang compiler to v2024.0.6
+
 ## 2023-06-16
 
 * Added Metal Shader Converter

--- a/build.cake
+++ b/build.cake
@@ -395,6 +395,7 @@ Task("Download-Slang")
     DownloadSlang("0.18.0");
     DownloadSlang("0.18.25");
     DownloadSlang("0.24.20");
+    DownloadSlang("2024.0.6");
   });
 
 Task("Download-HLSLParser")


### PR DESCRIPTION
As the tital says, this updates slang to a newer version since current version used by shader playground is quite old. If there is interest in always fetching the latest version I can try to integrate this. Though I am not sure if we should try to fetch the binaries or build from source?